### PR TITLE
Enable teacher inference in separate process

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,12 @@ To launch DistillKit, use the following command:
 ```bash
 accelerate launch distil_logits.py
 ```
-
 You can replace `distil_logits.py` with whichever script you want to use.
+
+Each training script spawns a separate process for the teacher model. The
+student process sends batches to the teacher via a queue and receives the
+precomputed logits or hidden states. Make sure you have a free GPU (or set the
+teacher to run on CPU inside the script) before launching.
 
 ### Advanced Configurations
 

--- a/distil_hidden.py
+++ b/distil_hidden.py
@@ -1,12 +1,15 @@
 import os
 import torch
 import torch.nn.functional as F
+import torch.multiprocessing as mp
 from datasets import load_dataset
 from trl import SFTTrainer
-from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
+from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments, AutoConfig
 from accelerate import Accelerator
 import yaml
 
+# Ensure multiprocessing uses spawn start method
+mp.set_start_method("spawn", force=True)
 # Configuration
 config = {
     "project_name": "distil-multilayer",
@@ -108,7 +111,7 @@ model_kwargs = {"torch_dtype": torch.bfloat16 if config["training"]["bf16"] else
 if config["model_config"]["use_flash_attention"]:
     model_kwargs["attn_implementation"] = "flash_attention_2"
 
-teacher_model = AutoModelForCausalLM.from_pretrained(config["models"]["teacher"], **model_kwargs).to(device)
+teacher_config = AutoConfig.from_pretrained(config["models"]["teacher"])
 student_model = AutoModelForCausalLM.from_pretrained(config["models"]["student"], **model_kwargs).to(device)
 
 class MultiLayerAdaptationLayer(torch.nn.Module):
@@ -137,11 +140,31 @@ class MultiLayerAdaptationLayer(torch.nn.Module):
 
 adaptation_layer = MultiLayerAdaptationLayer(
     student_model.config.hidden_size,
-    teacher_model.config.hidden_size,
+    teacher_config.hidden_size,
     student_model.config.num_hidden_layers,
-    teacher_model.config.num_hidden_layers,
+    teacher_config.num_hidden_layers,
     dtype=torch.bfloat16
 ).to(device)
+
+class TeacherProcess(mp.Process):
+    def __init__(self, model_name, queue_in, queue_out, device="cuda:0"):
+        super().__init__()
+        self.model_name = model_name
+        self.queue_in = queue_in
+        self.queue_out = queue_out
+        self.device = device
+
+    def run(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_name).to(self.device)
+        model.eval()
+        while True:
+            batch = self.queue_in.get()
+            if batch is None:
+                break
+            batch = {k: torch.tensor(v).to(self.device) for k, v in batch.items()}
+            with torch.no_grad():
+                outputs = model(**batch, output_hidden_states=True)
+            self.queue_out.put([h.cpu() for h in outputs.hidden_states])
 
 class CustomSFTTrainer(SFTTrainer):
     def __init__(self, *args, **kwargs):
@@ -161,16 +184,17 @@ class CustomSFTTrainer(SFTTrainer):
         
         original_loss = student_outputs.loss
 
-        self.teacher_model = self.teacher_model
-        teacher_model = self.teacher_model.module if hasattr(self.teacher_model, 'module') else self.teacher_model
+        teacher_inputs = {
+            "input_ids": inputs["teacher_input_ids"].detach().cpu(),
+            "attention_mask": inputs["teacher_attention_mask"].detach().cpu(),
+        }
+        self.queue_in.put(teacher_inputs)
+        teacher_hidden_states = [t.to(student_outputs.hidden_states[0].device) for t in self.queue_out.get()]
 
-        with torch.no_grad():
-            teacher_inputs = {
-                "input_ids": inputs["teacher_input_ids"],
-                "attention_mask": inputs["teacher_attention_mask"],
-            }
-            
-            teacher_outputs = teacher_model(**teacher_inputs, output_hidden_states=True)
+        class Dummy:
+            pass
+        teacher_outputs = Dummy()
+        teacher_outputs.hidden_states = teacher_hidden_states
 
         custom_loss = self.distillation_loss(student_outputs, teacher_outputs, inputs, original_loss)
         return (custom_loss, student_outputs) if return_outputs else custom_loss
@@ -214,6 +238,12 @@ training_arguments = TrainingArguments(
     remove_unused_columns=False,
 )
 
+# Set up multiprocessing queues and teacher process
+queue_in = mp.Queue(maxsize=8)
+queue_out = mp.Queue(maxsize=8)
+teacher_process = TeacherProcess(config["models"]["teacher"], queue_in, queue_out)
+teacher_process.start()
+
 # Create the custom SFT Trainer
 trainer = CustomSFTTrainer(
     model=student_model,
@@ -225,10 +255,11 @@ trainer = CustomSFTTrainer(
 )
 
 # Add these attributes to the trainer
-trainer.teacher_model = teacher_model
 trainer.adaptation_layer = adaptation_layer
 trainer.student_tokenizer = student_tokenizer
 trainer.teacher_tokenizer = teacher_tokenizer
+trainer.queue_in = queue_in
+trainer.queue_out = queue_out
 
 # Prepare for distributed training
 trainer = accelerator.prepare(trainer)
@@ -241,3 +272,7 @@ trainer.save_model(config["training"]["output_dir"])
 
 # Save the adaptation layer
 torch.save(adaptation_layer.state_dict(), os.path.join(config["training"]["output_dir"], "adaptation_layer.pth"))
+
+# Shutdown the teacher process
+queue_in.put(None)
+teacher_process.join()

--- a/distil_logits.py
+++ b/distil_logits.py
@@ -1,11 +1,14 @@
 import os
 import torch
 import torch.nn.functional as F
+import torch.multiprocessing as mp
 from datasets import load_dataset
 from trl import SFTTrainer, SFTConfig
 from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
 import yaml
 
+# Ensure multiprocessing uses spawn start method
+mp.set_start_method("spawn", force=True)
 # Configuration
 config = {
     "project_name": "distil-logits",
@@ -104,7 +107,7 @@ model_kwargs = {"torch_dtype": torch.bfloat16}
 if config["model_config"]["use_flash_attention"]:
     model_kwargs["attn_implementation"] = "flash_attention_2"
 
-teacher_model = AutoModelForCausalLM.from_pretrained(config["models"]["teacher"], **model_kwargs)
+# Load only the student model in the main process
 student_model = AutoModelForCausalLM.from_pretrained(config["models"]["student"], **model_kwargs)
 
 # Optionally freeze layers of the student model based on spectrum configuration
@@ -132,20 +135,41 @@ def pad_logits(student_logits, teacher_logits):
         return (torch.cat([student_logits, pad_tensor], dim=-1), teacher_logits) if student_size < teacher_size else (student_logits, torch.cat([teacher_logits, pad_tensor], dim=-1))
     return student_logits, teacher_logits
 
+class TeacherProcess(mp.Process):
+    def __init__(self, model_name, queue_in, queue_out, device="cuda:0"):
+        super().__init__()
+        self.model_name = model_name
+        self.queue_in = queue_in
+        self.queue_out = queue_out
+        self.device = device
+
+    def run(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_name).to(self.device)
+        model.eval()
+        while True:
+            batch = self.queue_in.get()
+            if batch is None:
+                break
+            batch = {k: torch.tensor(v).to(self.device) for k, v in batch.items()}
+            with torch.no_grad():
+                outputs = model(**batch)
+            self.queue_out.put(outputs.logits.cpu())
+
 class LogitsTrainer(SFTTrainer):
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         device = next(model.parameters()).device
         inputs = {k: v.to(device) if hasattr(v, 'to') else v for k, v in inputs.items()}
-        self.teacher_model = self.teacher_model.to(device)
-        
+
         student_model = model.module if hasattr(model, 'module') else model
-        teacher_model = self.teacher_model.module if hasattr(self.teacher_model, 'module') else self.teacher_model
+
+        # Send inputs to teacher process and wait for logits
+        cpu_inputs = {k: v.detach().cpu() for k, v in inputs.items() if k in ["input_ids", "attention_mask"]}
+        self.queue_in.put(cpu_inputs)
+        teacher_logits = self.queue_out.get().to(device)
 
         student_outputs = student_model(**inputs)
-        with torch.no_grad():
-            teacher_outputs = teacher_model(**inputs)
 
-        custom_loss = self.distillation_loss(model, student_outputs.logits, teacher_outputs.logits, inputs, student_outputs.loss)
+        custom_loss = self.distillation_loss(model, student_outputs.logits, teacher_logits, inputs, student_outputs.loss)
         return (custom_loss, student_outputs) if return_outputs else custom_loss
 
     def distillation_loss(self, model, student_logits, teacher_logits, inputs, original_loss):
@@ -166,22 +190,30 @@ class LogitsTrainer(SFTTrainer):
 # Training arguments
 training_arguments = TrainingArguments(**config["training"])
 
+# Set up multiprocessing queues and teacher process
+queue_in = mp.Queue(maxsize=8)
+queue_out = mp.Queue(maxsize=8)
+teacher_process = TeacherProcess(config["models"]["teacher"], queue_in, queue_out)
+teacher_process.start()
+
 # Create the custom SFT Trainer
 trainer = LogitsTrainer(
     model=student_model,
     train_dataset=tokenized_dataset["train"],
     eval_dataset=tokenized_dataset["test"],
-    #tokenizer=student_tokenizer,
     args=training_arguments,
-    #max_seq_length=config["tokenizer"]["max_length"],
-    #dataset_text_field="text",
 )
 
-# Add the teacher model to the trainer
-trainer.teacher_model = teacher_model
+# Pass the queues to the trainer
+trainer.queue_in = queue_in
+trainer.queue_out = queue_out
 
 # Train the model
 trainer.train(resume_from_checkpoint=config["training"]["resume_from_checkpoint"])
 
 # Save the final model
 trainer.save_model(config["training"]["output_dir"])
+
+# Shutdown the teacher process
+queue_in.put(None)
+teacher_process.join()


### PR DESCRIPTION
## Summary
- run teacher inference in a multiprocessing worker in `distil_logits.py`
- fetch teacher logits from a queue in the trainer's `compute_loss`
- apply the same multiprocessing pattern to hidden-state distillation
- document concurrent teacher/student launches in README

## Testing
- `python -m py_compile distil_logits.py`
- `python -m py_compile distil_hidden.py`

------
https://chatgpt.com/codex/tasks/task_e_6845362061c48324a19b7a709596b3c9