### PR TITLE
Add teacher output caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,31 @@ We provide sample DeepSpeed configuration files in the `./deepspeed_configs` dir
 
 To use a specific DeepSpeed configuration, you can specify it in your accelerate config.
 
+### Caching Teacher Outputs
+
+Running teacher models can be expensive. DistillKit can read logits or hidden states from a precomputed LMDB cache.
+
+1. Generate the cache using `cache_teacher_outputs.py`:
+
+```bash
+python cache_teacher_outputs.py --dataset <dataset_name> --split train \
+    --teacher <teacher_model> --output teacher_logits.lmdb --mode logits
+# use --mode hidden to cache hidden states
+```
+
+2. In your training configuration, set the cache path:
+
+```python
+config = {
+    # ...
+    "cache": {
+        "teacher_logits": "teacher_logits.lmdb",  # or use teacher_hidden for hidden state caching
+    }
+}
+```
+
+When a cache path is provided, `distil_logits.py` or `distil_hidden.py` will skip teacher inference and load the stored tensors instead.
+
 ## Distillation Methods
 
 DistillKit supports two primary distillation methods:

--- a/cache_teacher_outputs.py
+++ b/cache_teacher_outputs.py
@@ -1,0 +1,95 @@
+import os
+import io
+import argparse
+import torch
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+try:
+    from vllm import LLM
+    VLLM_AVAILABLE = True
+except Exception:
+    VLLM_AVAILABLE = False
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Cache teacher outputs")
+    parser.add_argument("--dataset", required=True, help="Dataset name")
+    parser.add_argument("--split", default="train", help="Dataset split")
+    parser.add_argument("--teacher", required=True, help="Teacher model")
+    parser.add_argument("--output", required=True, help="Path to LMDB output")
+    parser.add_argument("--max_length", type=int, default=4096)
+    parser.add_argument("--mode", choices=["logits", "hidden"], default="logits")
+    parser.add_argument("--use_vllm", action="store_true", help="Use vLLM if available")
+    return parser.parse_args()
+
+
+def sharegpt_format(example, tokenizer):
+    conversations = example["conversations"]
+    message = []
+    if isinstance(conversations, list):
+        for conv in conversations:
+            if conv.get("from") == "human":
+                message.append({"role": "user", "content": conv.get("value", "")})
+            elif conv.get("from") == "gpt":
+                message.append({"role": "assistant", "content": conv.get("value", "")})
+            elif conv.get("from") == "system":
+                message.insert(0, {"role": "system", "content": conv.get("value", "")})
+    if not any(m.get("role") == "system" for m in message):
+        message.insert(0, {"role": "system", "content": "You are a helpful assistant."})
+    text = tokenizer.apply_chat_template(message, tokenize=False, add_generation_prompt=True)
+    return {"text": text}
+
+
+def main():
+    args = parse_args()
+    dataset = load_dataset(args.dataset, split=args.split)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.teacher)
+
+    dataset = dataset.map(lambda ex: sharegpt_format(ex, tokenizer), remove_columns=dataset.column_names)
+
+    def tok_fn(examples, indices):
+        tokens = tokenizer(
+            examples["text"],
+            truncation=True,
+            max_length=args.max_length,
+            padding="max_length",
+        )
+        tokens["id"] = indices
+        return tokens
+
+    dataset = dataset.map(tok_fn, batched=True, with_indices=True)
+
+    import lmdb
+    env = lmdb.open(args.output, map_size=int(1e12))
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    if args.use_vllm and VLLM_AVAILABLE and args.mode == "logits":
+        llm = LLM(model=args.teacher)
+        for ex in dataset:
+            prompt = tokenizer.decode(ex["input_ids"])
+            outputs = llm.generate([prompt])[0]
+            logits = torch.tensor(outputs.logits, dtype=torch.float16)
+            buf = io.BytesIO()
+            torch.save(logits, buf)
+            with env.begin(write=True) as txn:
+                txn.put(str(ex["id"]).encode(), buf.getvalue())
+    else:
+        model = AutoModelForCausalLM.from_pretrained(args.teacher).to(device)
+        model.eval()
+        for ex in dataset:
+            input_ids = torch.tensor([ex["input_ids"]]).to(device)
+            attention_mask = torch.tensor([ex["attention_mask"]]).to(device)
+            with torch.no_grad():
+                out = model(input_ids=input_ids, attention_mask=attention_mask, output_hidden_states=args.mode=="hidden")
+            data = out.logits[0].cpu() if args.mode=="logits" else [h[0].cpu() for h in out.hidden_states]
+            buf = io.BytesIO()
+            torch.save(data, buf)
+            with env.begin(write=True) as txn:
+                txn.put(str(ex["id"]).encode(), buf.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/distil_hidden.py
+++ b/distil_hidden.py
@@ -1,4 +1,5 @@
 import os
+import io
 import torch
 import torch.nn.functional as F
 from datasets import load_dataset
@@ -48,6 +49,9 @@ config = {
     },
     "model_config": {
         "use_flash_attention": True
+    },
+    "cache": {
+        "teacher_hidden": None  # Path to LMDB with cached teacher hidden states
     }
 }
 
@@ -71,7 +75,7 @@ student_tokenizer = AutoTokenizer.from_pretrained(config["models"]["student"])
 # Apply chat template to student tokenizer
 student_tokenizer.chat_template = config["tokenizer"]["chat_template"]
 
-def prepare_dataset(example):
+def prepare_dataset(example, idx):
     system = "You are a helpful assistant chatbot."
     conversations = example['conversations']
     
@@ -94,12 +98,25 @@ def prepare_dataset(example):
         "attention_mask": student_encodings["attention_mask"],
         "teacher_input_ids": teacher_encodings["input_ids"],
         "teacher_attention_mask": teacher_encodings["attention_mask"],
+        "id": idx,
     }
 
 # Preprocess and tokenize the dataset
 print("Preprocessing and tokenizing dataset...")
 original_columns = dataset.column_names
-dataset = dataset.map(prepare_dataset, remove_columns=original_columns)
+dataset = dataset.map(
+    prepare_dataset,
+    remove_columns=original_columns,
+    with_indices=True,
+)
+
+# Optional teacher hidden state cache
+cache_env = None
+if config.get("cache", {}).get("teacher_hidden"):
+    import lmdb
+    cache_env = lmdb.open(
+        config["cache"]["teacher_hidden"], readonly=True, lock=False
+    )
 
 print("Dataset preparation complete. Loading models...")
 
@@ -150,6 +167,7 @@ class CustomSFTTrainer(SFTTrainer):
         super(CustomSFTTrainer, self).__init__(*args, **kwargs)
 
     def compute_loss(self, model, inputs, return_outputs=False):
+        sample_id = inputs.pop("id") if "id" in inputs else None
         student_inputs = {
             "input_ids": inputs["input_ids"],
             "attention_mask": inputs["attention_mask"],
@@ -164,13 +182,20 @@ class CustomSFTTrainer(SFTTrainer):
         self.teacher_model = self.teacher_model
         teacher_model = self.teacher_model.module if hasattr(self.teacher_model, 'module') else self.teacher_model
 
-        with torch.no_grad():
-            teacher_inputs = {
-                "input_ids": inputs["teacher_input_ids"],
-                "attention_mask": inputs["teacher_attention_mask"],
-            }
-            
-            teacher_outputs = teacher_model(**teacher_inputs, output_hidden_states=True)
+        if self.cache_env is not None and sample_id is not None:
+            import io, torch as _torch
+            with self.cache_env.begin() as txn:
+                buf = txn.get(str(sample_id.item() if hasattr(sample_id, 'item') else sample_id).encode())
+            teacher_hidden = _torch.load(io.BytesIO(buf))
+            teacher_outputs = type('obj', (object,), {'hidden_states': teacher_hidden})
+        else:
+            with torch.no_grad():
+                teacher_inputs = {
+                    "input_ids": inputs["teacher_input_ids"],
+                    "attention_mask": inputs["teacher_attention_mask"],
+                }
+
+                teacher_outputs = teacher_model(**teacher_inputs, output_hidden_states=True)
 
         custom_loss = self.distillation_loss(student_outputs, teacher_outputs, inputs, original_loss)
         return (custom_loss, student_outputs) if return_outputs else custom_loss
@@ -229,6 +254,7 @@ trainer.teacher_model = teacher_model
 trainer.adaptation_layer = adaptation_layer
 trainer.student_tokenizer = student_tokenizer
 trainer.teacher_tokenizer = teacher_tokenizer
+trainer.cache_env = cache_env
 
 # Prepare for distributed training
 trainer = accelerator.prepare(trainer)

--- a/distil_logits.py
+++ b/distil_logits.py
@@ -1,4 +1,5 @@
 import os
+import io
 import torch
 import torch.nn.functional as F
 from datasets import load_dataset
@@ -44,6 +45,9 @@ config = {
     },
     "model_config": {
         "use_flash_attention": True
+    },
+    "cache": {
+        "teacher_logits": None  # Path to LMDB file with cached teacher logits
     }
     # "spectrum": {
     #     "layers_to_unfreeze": "/workspace/spectrum/snr_results_Qwen-Qwen2-1.5B_unfrozenparameters_50percent.yaml" # You can pass a spectrum yaml file here to freeze layers identified by spectrum.
@@ -91,11 +95,31 @@ print("Preprocessing and tokenizing dataset...")
 original_columns = dataset.column_names
 dataset = dataset.map(sharegpt_format, remove_columns=original_columns)
 
-def tokenize_function(examples):
-    return student_tokenizer(examples["text"], truncation=True, max_length=config["tokenizer"]["max_length"], padding="max_length")
-
-tokenized_dataset = dataset.map(tokenize_function, batched=True, num_proc=8, remove_columns=["text"])
+def tokenize_function(examples, indices):
+    tokens = student_tokenizer(
+        examples["text"],
+        truncation=True,
+        max_length=config["tokenizer"]["max_length"],
+        padding="max_length",
+    )
+    tokens["id"] = indices
+    return tokens
+tokenized_dataset = dataset.map(
+    tokenize_function,
+    batched=True,
+    with_indices=True,
+    num_proc=8,
+    remove_columns=["text"],
+)
 tokenized_dataset = tokenized_dataset.train_test_split(test_size=0.1)
+
+# Optional teacher logits cache
+cache_env = None
+if config.get("cache", {}).get("teacher_logits"):
+    import lmdb
+    cache_env = lmdb.open(
+        config["cache"]["teacher_logits"], readonly=True, lock=False
+    )
 
 print("Dataset preparation complete. Loading models...")
 
@@ -135,17 +159,25 @@ def pad_logits(student_logits, teacher_logits):
 class LogitsTrainer(SFTTrainer):
     def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         device = next(model.parameters()).device
+        sample_id = inputs.pop("id") if "id" in inputs else None
         inputs = {k: v.to(device) if hasattr(v, 'to') else v for k, v in inputs.items()}
         self.teacher_model = self.teacher_model.to(device)
-        
+
         student_model = model.module if hasattr(model, 'module') else model
         teacher_model = self.teacher_model.module if hasattr(self.teacher_model, 'module') else self.teacher_model
 
         student_outputs = student_model(**inputs)
-        with torch.no_grad():
-            teacher_outputs = teacher_model(**inputs)
+        if self.cache_env is not None and sample_id is not None:
+            import io, torch as _torch
+            with self.cache_env.begin() as txn:
+                buf = txn.get(str(sample_id.item() if hasattr(sample_id, 'item') else sample_id).encode())
+            teacher_logits = _torch.load(io.BytesIO(buf)).to(device)
+        else:
+            with torch.no_grad():
+                teacher_outputs = teacher_model(**inputs)
+            teacher_logits = teacher_outputs.logits
 
-        custom_loss = self.distillation_loss(model, student_outputs.logits, teacher_outputs.logits, inputs, student_outputs.loss)
+        custom_loss = self.distillation_loss(model, student_outputs.logits, teacher_logits, inputs, student_outputs.loss)
         return (custom_loss, student_outputs) if return_outputs else custom_loss
 
     def distillation_loss(self, model, student_logits, teacher_logits, inputs, original_loss):
@@ -164,7 +196,10 @@ class LogitsTrainer(SFTTrainer):
         return config["distillation"]["alpha"] * loss_kd + (1 - config["distillation"]["alpha"]) * original_loss
 
 # Training arguments
-training_arguments = TrainingArguments(**config["training"])
+training_arguments = TrainingArguments(
+    **config["training"],
+    remove_unused_columns=False,
+)
 
 # Create the custom SFT Trainer
 trainer = LogitsTrainer(
@@ -179,6 +214,7 @@ trainer = LogitsTrainer(
 
 # Add the teacher model to the trainer
 trainer.teacher_model = teacher_model
+trainer.cache_env = cache_env
 
 # Train the model
 trainer.train(resume_from_checkpoint=config["training"]["resume_from_checkpoint"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ safetensors
 transformers==4.51.3
 trl
 hf_transfer
+lmdb
+vllm; extra == "vllm"


### PR DESCRIPTION
## Summary
- allow teacher logits or hidden states to be loaded from LMDB
- implement optional caching in distil scripts
- add `cache_teacher_outputs.py` helper
- document caching workflow in README
- add `lmdb` and optional `vllm` dependencies

## Testing
- `python -m py_compile distil_logits.py distil_hidden.py cache_teacher_outputs.py`
- `pip install -r requirements.txt` *(fails: large torch download)*

------
https://chatgpt.com/codex/tasks/task_e_6845377c6cdc8324aa80314a0d209dd7