### PR TITLE
Add optional vLLM teacher backend

### DIFF
--- a/distil_hidden.py
+++ b/distil_hidden.py
@@ -46,6 +46,7 @@ config = {
         "temperature": 2.0,
         "alpha": 0.5
     },
+    "teacher_backend": "transformers",
     "model_config": {
         "use_flash_attention": True
     }
@@ -108,7 +109,11 @@ model_kwargs = {"torch_dtype": torch.bfloat16 if config["training"]["bf16"] else
 if config["model_config"]["use_flash_attention"]:
     model_kwargs["attn_implementation"] = "flash_attention_2"
 
-teacher_model = AutoModelForCausalLM.from_pretrained(config["models"]["teacher"], **model_kwargs).to(device)
+if config.get("teacher_backend") == "vllm":
+    from vllm import LLM
+    teacher_model = LLM(model=config["models"]["teacher"])
+else:
+    teacher_model = AutoModelForCausalLM.from_pretrained(config["models"]["teacher"], **model_kwargs).to(device)
 student_model = AutoModelForCausalLM.from_pretrained(config["models"]["student"], **model_kwargs).to(device)
 
 class MultiLayerAdaptationLayer(torch.nn.Module):
@@ -169,8 +174,12 @@ class CustomSFTTrainer(SFTTrainer):
                 "input_ids": inputs["teacher_input_ids"],
                 "attention_mask": inputs["teacher_attention_mask"],
             }
-            
-            teacher_outputs = teacher_model(**teacher_inputs, output_hidden_states=True)
+            if config.get("teacher_backend") == "vllm" and hasattr(teacher_model, "generate"):
+                # Use underlying HF model for hidden states when teacher is vLLM
+                hf_model = teacher_model.get_model() if hasattr(teacher_model, "get_model") else teacher_model.llm_engine.model_runner.model
+                teacher_outputs = hf_model(**teacher_inputs, output_hidden_states=True)
+            else:
+                teacher_outputs = teacher_model(**teacher_inputs, output_hidden_states=True)
 
         custom_loss = self.distillation_loss(student_outputs, teacher_outputs, inputs, original_loss)
         return (custom_loss, student_outputs) if return_outputs else custom_loss

--- a/distil_logits.py
+++ b/distil_logits.py
@@ -42,6 +42,7 @@ config = {
         "temperature": 2.0,
         "alpha": 0.5
     },
+    "teacher_backend": "transformers",
     "model_config": {
         "use_flash_attention": True
     }
@@ -104,7 +105,11 @@ model_kwargs = {"torch_dtype": torch.bfloat16}
 if config["model_config"]["use_flash_attention"]:
     model_kwargs["attn_implementation"] = "flash_attention_2"
 
-teacher_model = AutoModelForCausalLM.from_pretrained(config["models"]["teacher"], **model_kwargs)
+if config.get("teacher_backend") == "vllm":
+    from vllm import LLM
+    teacher_model = LLM(model=config["models"]["teacher"])
+else:
+    teacher_model = AutoModelForCausalLM.from_pretrained(config["models"]["teacher"], **model_kwargs)
 student_model = AutoModelForCausalLM.from_pretrained(config["models"]["student"], **model_kwargs)
 
 # Optionally freeze layers of the student model based on spectrum configuration
@@ -143,9 +148,28 @@ class LogitsTrainer(SFTTrainer):
 
         student_outputs = student_model(**inputs)
         with torch.no_grad():
-            teacher_outputs = teacher_model(**inputs)
+            if config.get("teacher_backend") == "vllm":
+                from vllm import SamplingParams
+                seq_lens = inputs["attention_mask"].sum(dim=1).tolist()
+                prompts = [teacher_tokenizer.decode(ids[:l]) for ids, l in zip(inputs["input_ids"], seq_lens)]
+                params = SamplingParams(temperature=config["distillation"]["temperature"], logprobs=len(teacher_tokenizer), max_tokens=0)
+                outputs = teacher_model.generate(prompts, params)
+                logits_list = []
+                for out in outputs:
+                    token_probs = out.prompt_logprobs
+                    step_logits = []
+                    for t_dict in token_probs:
+                        logit_vec = torch.full((len(teacher_tokenizer),), float('-inf'))
+                        for tid, lp in t_dict.items():
+                            logit_vec[tid] = lp
+                        step_logits.append(logit_vec)
+                    logits_list.append(torch.stack(step_logits))
+                teacher_logits = torch.stack(logits_list).to(device)
+            else:
+                teacher_outputs = teacher_model(**inputs)
+                teacher_logits = teacher_outputs.logits
 
-        custom_loss = self.distillation_loss(model, student_outputs.logits, teacher_outputs.logits, inputs, student_outputs.loss)
+        custom_loss = self.distillation_loss(model, student_outputs.logits, teacher_logits, inputs, student_outputs.loss)
         return (custom_loss, student_outputs) if return_outputs else custom_loss
 
     def distillation_loss(self, model, student_logits, teacher_logits, inputs, original_loss):

--- a/dpo_distil_logits.py
+++ b/dpo_distil_logits.py
@@ -58,6 +58,7 @@ cfg = {
         "kd_temperature": 1.0,
         "kd_weight": 1e-3,
     },
+    "teacher_backend": "transformers",
     "wandb": {
         "entity": "my-team",
         "name": "exp-name",  # run name
@@ -228,7 +229,10 @@ class DPOTrainerWithKD(DPOTrainer):
         """Compute the DPO loss and other metrics for the given batch of inputs for train or test."""
         metrics = {}
 
-        teacher_output, teacher_logits = self.concatenated_forward(self.teacher_model.eval(), batch, no_grad=True)
+        teacher_model = self.teacher_model
+        if cfg.get("teacher_backend") != "vllm":
+            teacher_model = teacher_model.eval()
+        teacher_output, teacher_logits = self.concatenated_forward(teacher_model, batch, no_grad=True)
         model_output, logits = self.concatenated_forward(model, batch)
 
         logit_kd_loss = self.distillation_loss(logits, teacher_logits)
@@ -388,7 +392,27 @@ class DPOTrainerWithKD(DPOTrainer):
 
             if no_grad:
                 with torch.no_grad():
-                    outputs = self.teacher_model(input_ids, **model_kwargs)
+                    if cfg.get("teacher_backend") == "vllm":
+                        from vllm import SamplingParams
+                        seq_lens = attention_mask.sum(dim=1).tolist()
+                        prompts = [tok_student.decode(ids[:l]) for ids, l in zip(input_ids, seq_lens)]
+                        params = SamplingParams(temperature=cfg["dpo"]["kd_temperature"], logprobs=len(tok_student), max_tokens=0)
+                        outs = self.teacher_model.generate(prompts, params)
+                        logits_list = []
+                        for out in outs:
+                            token_probs = out.prompt_logprobs
+                            step_logits = []
+                            for t_dict in token_probs:
+                                logit_vec = torch.full((len(tok_student),), float('-inf'), device=input_ids.device)
+                                for tid, lp in t_dict.items():
+                                    logit_vec[tid] = lp
+                                step_logits.append(logit_vec)
+                            logits_list.append(torch.stack(step_logits))
+                        logits = torch.stack(logits_list)
+                        class O: pass
+                        outputs = O(); outputs.logits = logits
+                    else:
+                        outputs = self.teacher_model(input_ids, **model_kwargs)
             else:
                 outputs = model(input_ids, **model_kwargs)
             logits = outputs.logits
@@ -556,11 +580,14 @@ student_model = AutoModelForCausalLM.from_pretrained(
     cfg["models"]["student"], quantization_config=bnb_cfg
 )
 student_model.config.use_cache = False        # required for gradient-checkpointing
-
-teacher_model = AutoModelForCausalLM.from_pretrained(
-    cfg["models"]["teacher"], quantization_config=bnb_cfg
-)
-teacher_model.eval()                          # we never train the teacher
+if cfg.get("teacher_backend") == "vllm":
+    from vllm import LLM
+    teacher_model = LLM(model=cfg["models"]["teacher"])
+else:
+    teacher_model = AutoModelForCausalLM.from_pretrained(
+        cfg["models"]["teacher"], quantization_config=bnb_cfg
+    )
+    teacher_model.eval()                          # we never train the teacher
 
 
 train_cfg = DPOConfig(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ safetensors
 transformers==4.51.3
 trl
 hf_transfer
+vllm

--- a/setup.sh
+++ b/setup.sh
@@ -9,5 +9,8 @@ pip install wheel packaging ninja
 # Install flash-attn and deepspeed
 pip install flash-attn deepspeed
 
+# Install vLLM separately (requires torch to be installed first)
+pip install vllm
+
 # Install requirements from requirements.txt
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add `vllm` requirement and install in `setup.sh`
- support loading teacher with `vllm.LLM` via new `teacher_backend` flag
- query the vLLM engine for logits when configured

## Testing
- `python -m py_compile distil_logits.py distil_hidden.py dpo_distil_logits.py`

------
https://chatgpt.com/codex/tasks/task_e_6845536d5f188324a617ebd176c5934a